### PR TITLE
don't hang on error responses with keep-alive

### DIFF
--- a/lib/celluloid/eventsource.rb
+++ b/lib/celluloid/eventsource.rb
@@ -155,12 +155,11 @@ module Celluloid
           end
 
           if parser.status_code != 200
-            until @socket.eof?
-              parser << readline_with_timeout(@socket)
+            # Consume response body if present
+            if !parser.headers["Content-Length"].nil?
+              parser << @socket.read(parser.headers["Content-Length"].to_i)
             end
-            # If the server returns a non-200, we don't want to close-- we just want to
-            # report an error
-            # close
+            close
             @on[:error].call({status_code: parser.status_code, body: parser.chunk})
           elsif parser.headers['Content-Type'] && parser.headers['Content-Type'].include?("text/event-stream")
             @chunked = !parser.headers["Transfer-Encoding"].nil? && parser.headers["Transfer-Encoding"].include?("chunked")

--- a/lib/celluloid/eventsource.rb
+++ b/lib/celluloid/eventsource.rb
@@ -93,6 +93,7 @@ module Celluloid
 
     def close
       @socket.close if @socket
+      @socket = nil
       @ready_state = CLOSED
     end
 

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -91,7 +91,7 @@ class DummyServer < WEBrick::HTTPServer
     def do_GET(req, res)
       res.content_type = 'application/json; charset=utf-8'
       res.status = 400
-      res.keep_alive = false  # true by default
+      res.keep_alive = true  # ensure that we can correctly read error response body on a keep-alive connection
       res.body = '{"msg": "blop"}'
     end
   end


### PR DESCRIPTION
We inherited this bug from the original repo: if the server returns an HTTP error, but does not close the connection for us, we will hang trying to read the response body even if there is a `Content-Length: 0` header.

I believe the more correct behavior is: if there is a `Content-Length` header, read only that number of bytes. That means we don't support chunked mode for error responses, but I don't think it is worthwhile to implement that much HTTP logic (unless there's a way to make `http_parser.rb` do it for us; I couldn't figure that out). Note, in our actual use case for LD streamer, there never is anything in the response body anyway.