### PR TITLE
migrate build to Circle 2

### DIFF
--- a/.circle.yml
+++ b/.circle.yml
@@ -1,7 +1,0 @@
-ruby:
-  version: 2.3.1
-
-dependencies:
-  pre:
-    - gem update bundler
-    - bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,84 @@
+version: 2
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-misc-rubies
+      - test-2.2
+      - test-2.3
+      - test-2.4
+      - test-jruby-9.1
+
+ruby-docker-template: &ruby-docker-template
+  steps:
+    - checkout
+    - run: |
+        if [[ $CIRCLE_JOB == test-jruby* ]]; then
+          gem install jruby-openssl; # required by bundler, no effect on Ruby MRI
+        fi
+    - run: gem install bundler
+    - run: bundle install
+    - run: mkdir ./rspec
+    - run: bundle exec rspec --format progress --format RspecJunitFormatter -o ./rspec/rspec.xml spec
+    - store_test_results:
+        path: ./rspec
+    - store_artifacts:
+        path: ./rspec
+
+jobs:
+  test-2.2:
+    <<: *ruby-docker-template
+    docker:
+      - image: circleci/ruby:2.2.9-jessie
+  test-2.3:
+    <<: *ruby-docker-template
+    docker:
+      - image: circleci/ruby:2.3.6-jessie
+  test-2.4:
+    <<: *ruby-docker-template
+    docker:
+      - image: circleci/ruby:2.4.3-jessie
+  test-jruby-9.1:
+    <<: *ruby-docker-template
+    docker:
+      - image: circleci/jruby:9-jdk
+
+  # The following very slow job uses an Ubuntu container to run the Ruby versions that
+  # CircleCI doesn't provide Docker images for.
+  test-misc-rubies:
+    machine:
+      image: circleci/classic:latest
+    environment:
+      - RUBIES: "ruby-2.1.9 ruby-2.0.0 ruby-1.9.3 jruby-9.0.5.0"
+    steps:
+      - checkout
+      - run:
+          name: install all Ruby versions
+          command: "parallel rvm install ::: $RUBIES"
+      - run:
+          name: bundle install for all versions
+          shell: /bin/bash -leo pipefail # need -l in order for "rvm use" to work
+          command: |
+            set -e;
+            for i in $RUBIES;
+            do
+              rvm use $i;
+              if [[ $i == jruby* ]]; then
+                gem install jruby-openssl; # required by bundler, no effect on Ruby MRI
+              fi
+              gem install bundler;
+              bundle install;
+              mv Gemfile.lock "Gemfile.lock.$i"
+            done
+      - run:
+          name: run tests for all versions
+          shell: /bin/bash -leo pipefail
+          command: |
+            set -e;
+            for i in $RUBIES;
+            do
+              rvm use $i;
+              cp "Gemfile.lock.$i" Gemfile.lock;
+              bundle exec rspec spec;
+            done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ ruby-docker-template: &ruby-docker-template
         if [[ $CIRCLE_JOB == test-jruby* ]]; then
           gem install jruby-openssl; # required by bundler, no effect on Ruby MRI
         fi
+    - run: ruby -v
     - run: gem install bundler
     - run: bundle install
     - run: mkdir ./rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
       - test-2.2
       - test-2.3
       - test-2.4
-      - test-jruby-9.1
+      #- test-jruby-9.1
 
 ruby-docker-template: &ruby-docker-template
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,11 @@ jobs:
     <<: *ruby-docker-template
     docker:
       - image: circleci/ruby:2.4.3-jessie
-  test-jruby-9.1:
-    <<: *ruby-docker-template
-    docker:
-      - image: circleci/jruby:9-jdk
+  # circleci/jruby:9-jdk now uses JRuby 9.2.0, which we are not yet compatible with
+  # test-jruby-9.1:
+  #   <<: *ruby-docker-template
+  #   docker:
+  #     - image: circleci/jruby:9-jdk
 
   # The following very slow job uses an Ubuntu container to run the Ruby versions that
   # CircleCI doesn't provide Docker images for.
@@ -54,7 +55,7 @@ jobs:
     machine:
       image: circleci/classic:latest
     environment:
-      - RUBIES: "ruby-2.1.9 ruby-2.0.0 ruby-1.9.3 jruby-9.0.5.0"
+      - RUBIES: "ruby-2.1.9 ruby-2.0.0 ruby-1.9.3 jruby-9.0.5.0 jruby-9.1.17.0"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2
 
+# This file should be updated whenever we change the list of supported Ruby versions
+# in the Ruby SDK build.
+
 workflows:
   version: 2
   test:

--- a/ld-celluloid-eventsource.gemspec
+++ b/ld-celluloid-eventsource.gemspec
@@ -28,5 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", '~> 10.1'
   spec.add_development_dependency "pry", '~> 0.9'
-  spec.add_development_dependency "rspec_junit_formatter", "~> 0.3.0"
+  if RUBY_VERSION >= "2.0.0"
+    spec.add_development_dependency "rspec_junit_formatter", "~> 0.3.0"
+  end
 end

--- a/ld-celluloid-eventsource.gemspec
+++ b/ld-celluloid-eventsource.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", '~> 10.1'
   spec.add_development_dependency "pry", '~> 0.9'
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.3.0"
 end


### PR DESCRIPTION
I basically copied the build from the Ruby SDK project, so it will test in all versions of Ruby that we support. The only difference is that we don't use Redis.